### PR TITLE
Apply urdf color/scale data

### DIFF
--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -192,7 +192,7 @@ pub struct ExtractedGeometry {
     pub index: usize,
     pub geometries: Vec<Geometry>,
     pub inertia_pose: Pose,
-    pub visual_poses: Vec<Pose>,
+    pub visuals: Vec<(Pose, Option<urdf_rs::Material>)>,
     pub colliders: Vec<Collider>,
     pub link: Link,
 }
@@ -211,17 +211,17 @@ pub fn extract_robot_geometry(robot: &UrdfAsset) -> Vec<ExtractedGeometry> {
                 .iter()
                 .map(|visual| visual.geometry.clone())
                 .collect();
-            let visual_poses = link
+            let visuals = link
                 .visual
                 .iter()
-                .map(|visual| visual.origin.clone())
+                .map(|visual| (visual.origin.clone(), visual.material.clone()))
                 .collect();
 
             ExtractedGeometry {
                 index,
                 geometries,
                 inertia_pose: link.inertial.origin.clone(),
-                visual_poses,
+                visuals,
                 link: link.clone(),
                 colliders,
             }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -309,8 +309,9 @@ fn sync_robot_geometry(
                     pose_rotation,
                 );
 
-                *transform =
-                    Transform::from_translation(final_translation).with_rotation(final_rotation);
+                *transform = transform
+                    .with_translation(final_translation)
+                    .with_rotation(final_rotation);
             }
         }
     }


### PR DESCRIPTION
Apply a URDF's color information and the mesh's scale data.
The example manipulator would appear as follows:
<img width="888" height="613" alt="image" src="https://github.com/user-attachments/assets/3e5fca51-e53a-4dcf-8ecf-f3456295431e" />

The scale was defined in the example racer.urdf file, but since I didn't know how to properly load it locally, I skipped this part. It worked correctly with my own URDF files.