### PR TITLE
Fix motor control events

### DIFF
--- a/examples/manipulator.rs
+++ b/examples/manipulator.rs
@@ -1,22 +1,39 @@
-use bevy::ecs::system::ScheduleSystem;
-use bevy::{
-    color::palettes::css::WHITE, input::common_conditions::input_toggle_active, prelude::*,
-};
+use bevy::input::common_conditions::input_toggle_active;
+use bevy::{color::palettes::css::WHITE, prelude::*};
 use bevy_infinite_grid::{InfiniteGridBundle, InfiniteGridPlugin};
 use bevy_inspector_egui::bevy_egui::EguiPlugin;
+use bevy_inspector_egui::bevy_egui::{egui, EguiContextPass, EguiContexts};
 use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_panorbit_camera::*;
 use bevy_rapier3d::prelude::*;
 use bevy_stl::StlPlugin;
-use bevy_urdf::control::ControlMotorPositions;
-use bevy_urdf::control::MotorProps;
-use bevy_urdf::plugin::RobotType;
+use bevy_urdf::control::{ControlMotorPositions, MotorProps};
+use bevy_urdf::plugin::{RobotType, URDFRobot};
 use bevy_urdf::spawn::{LoadRobot, RapierOption, RobotLoaded, SpawnRobot};
 use bevy_urdf::urdf_asset_loader::UrdfAsset;
 use bevy_urdf::URDFPlugin;
+use std::f32::consts::PI;
 
 #[derive(Resource)]
 struct UrdfRobotHandle(Option<Handle<UrdfAsset>>);
+
+struct MotorAngle {
+    angle: f32,
+    upper_limit: f32,
+    lower_limit: f32,
+    name: String,
+}
+
+#[derive(Resource, Default)]
+struct MotorAngles {
+    angles: Vec<MotorAngle>,
+    initialized: bool,
+}
+
+#[derive(Default, Resource, Clone, Debug, PartialEq)]
+struct LastJointData {
+    angles: Vec<f32>,
+}
 
 fn main() {
     App::new()
@@ -38,6 +55,10 @@ fn main() {
         .init_state::<AppState>()
         .insert_resource(ClearColor(Color::linear_rgb(1.0, 1.0, 1.0)))
         .insert_resource(UrdfRobotHandle(None))
+        .insert_resource(MotorAngles::default())
+        .insert_resource(LastJointData::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, start_simulation.run_if(in_state(AppState::Loading)))
         .add_systems(
             Update,
             (
@@ -49,9 +70,15 @@ fn main() {
                     .in_set(PhysicsSet::Writeback),
             ),
         )
-        .add_systems(Startup, setup)
-        .add_systems(Update, start_simulation.run_if(in_state(AppState::Loading)))
-        .add_systems(Update, (control_motors,))
+        .add_systems(
+            Update,
+            (
+                initialize_motors,
+                control_motors.after(PhysicsSet::Writeback),
+            )
+                .run_if(in_state(AppState::Simulation)),
+        )
+        .add_systems(EguiContextPass, motor_ui.before(control_motors))
         .run();
 }
 
@@ -107,6 +134,9 @@ fn setup(mut commands: Commands, mut ew_load_robot: EventWriter<LoadRobot>) {
         Transform::from_xyz(-0.019, 0.32, -0.793).looking_at(Vec3::ZERO, Vec3::Y),
         PanOrbitCamera {
             focus: Vec3::new(0.0, 0.0, 0.0),
+            button_orbit: MouseButton::Right,
+            button_pan: MouseButton::Right,
+            modifier_pan: Some(KeyCode::ShiftLeft),
             ..Default::default()
         },
     ));
@@ -129,54 +159,156 @@ fn setup(mut commands: Commands, mut ew_load_robot: EventWriter<LoadRobot>) {
     });
 }
 
+fn initialize_motors(
+    mut motor_angles: ResMut<MotorAngles>,
+    q_urdf_robots: Query<&URDFRobot>,
+    urdf_assets: Res<Assets<UrdfAsset>>,
+) {
+    if motor_angles.initialized {
+        return;
+    }
+
+    for urdf_robot in q_urdf_robots.iter() {
+        if let Some(urdf_asset) = urdf_assets.get(&urdf_robot.handle) {
+            motor_angles.angles.clear();
+
+            for (i, joint) in urdf_asset.robot.joints.iter().enumerate() {
+                match &joint.joint_type {
+                    urdf_rs::JointType::Revolute
+                    | urdf_rs::JointType::Continuous
+                    | urdf_rs::JointType::Prismatic => {
+                        let limit = &joint.limit;
+                        let mut lower = limit.lower as f32;
+                        let mut upper = limit.upper as f32;
+
+                        if (lower - upper).abs() < 0.001 {
+                            lower = -PI;
+                            upper = PI;
+                        }
+
+                        let angle: f32 = match i {
+                            1 => 0.0, // (-0.174533 + 1.74533) / 2.0,
+                            2 => (-2.74385 + 2.84121) / 2.0,
+                            3 => (-1.65806 + 1.65806) / 2.0,
+                            4 => (-1.69 + 1.69) / 2.0,
+                            5 => (-1.74533 + 1.74533) / 2.0,
+                            6 => 3.14, //(-1.41986 - 1.11986) / 2.0 + 1.0,
+                            _ => 1.0,
+                        };
+                        info!("{} {} rad(type: {:?})", joint.name, angle, joint.joint_type);
+                        motor_angles.angles.push(MotorAngle {
+                            angle,
+                            lower_limit: lower,
+                            upper_limit: upper,
+                            name: joint.name.clone(),
+                        })
+                    }
+                    _ => {
+                        info!(
+                            "Skipping joint: {} (type: {:?})",
+                            joint.name, joint.joint_type
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            motor_angles.initialized = true;
+            break;
+        }
+    }
+}
+
+fn motor_ui(mut contexts: EguiContexts, mut motor_angles: ResMut<MotorAngles>) {
+    if !motor_angles.initialized || motor_angles.angles.is_empty() {
+        return;
+    }
+
+    if let Some(ctx) = contexts.try_ctx_mut() {
+        let mut angles_changed = false;
+
+        egui::Window::new("Motor Control")
+            .default_pos(egui::pos2(20.0, 20.0))
+            .default_size(egui::vec2(400.0, 500.0))
+            .resizable(true)
+            .collapsible(true)
+            .show(ctx, |ui| {
+                let motor_count = motor_angles.angles.len();
+                ui.heading(format!("Motor Control ({} motors)", motor_count));
+
+                for MotorAngle {
+                    name,
+                    lower_limit,
+                    upper_limit,
+                    angle,
+                } in motor_angles.angles.iter_mut()
+                {
+                    let min_limit = *lower_limit;
+                    let max_limit = *upper_limit;
+                    let old_value = *angle;
+
+                    ui.horizontal(|ui| {
+                        ui.label(format!("{}: ", name));
+                        let response = ui.add(
+                            egui::Slider::new(angle, min_limit..=max_limit)
+                                .text("rad")
+                                .step_by(0.01),
+                        );
+                        ui.label(format!("{:.3}", angle));
+
+                        if response.changed() || (old_value - *angle).abs() > 0.001 {
+                            angles_changed = true;
+                        }
+                    });
+                }
+
+                if angles_changed {
+                    motor_angles.set_changed();
+                }
+            });
+    }
+}
+
 fn control_motors(
     robot_handle: Res<UrdfRobotHandle>,
     mut ew_control_motors: EventWriter<ControlMotorPositions>,
+    motor_angles: Res<MotorAngles>,
+    mut last_joint_data: ResMut<LastJointData>,
 ) {
-    // lower="-0.174533" upper="1.74533
-    // lower="-2.74385" upper="2.84121"
-    // lower="-1.65806" upper="1.65806"
-    // lower="-1.69" upper="1.69"
-    // lower="-1.74533" upper="1.74533"
-    // lower="-1.41986" upper="-1.11986"
+    if !motor_angles.initialized || motor_angles.angles.is_empty() {
+        return;
+    }
 
     if let Some(handle) = robot_handle.0.clone() {
-        let mut positions: Vec<f32> = Vec::new();
-        let mut motor_props: Vec<MotorProps> = Vec::new();
+        let current_angles = motor_angles
+            .angles
+            .iter()
+            .map(|a| a.angle)
+            .collect::<Vec<_>>();
+        let should_send = {
+            if last_joint_data.angles != current_angles {
+                last_joint_data.angles = current_angles.clone();
+                true
+            } else {
+                false
+            }
+        };
 
-        for i in 0..50 {
-            let mut value = 1.0;
-            // let i = i+1;
-            if i == 0 {
-                value = 0.0;
-            }
-            if i == 1 {
-                value = (-2.74385 + 2.84121) / 2.0;
-            }
-            if i == 2 {
-                value = (-1.65806 + 1.65806) / 2.0;
-            }
-            if i == 3 {
-                value = (-1.69 + 1.69) / 2.0;
-            }
-            if i == 4 {
-                value = (-1.74533 + 1.74533) / 2.0;
-            }
-            if i == 5 {
-                value = 3.14; // (-1.41986 - 1.11986) / 2.0 + 1.0;
-            }
+        if should_send {
+            let positions = current_angles;
+            let motor_props = vec![
+                MotorProps {
+                    stiffness: 17.8,
+                    damping: 0.6,
+                };
+                positions.len()
+            ];
 
-            positions.push(value); // rng.random_range(0.0..5.0));
-            motor_props.push(MotorProps {
-                stiffness: 17.8,
-                damping: 0.6,
+            ew_control_motors.write(ControlMotorPositions {
+                handle,
+                positions,
+                motor_props,
             });
         }
-
-        ew_control_motors.write(ControlMotorPositions {
-            handle,
-            positions,
-            motor_props,
-        });
     }
 }


### PR DESCRIPTION
Fixed an issue where the simulated robot wouldn't update when changing ControlMotorPositions or ControlMotorVelocities after either not writing to them for a specified period or continuously writing the same value.

This is because the rapier rigid-body automatically enters sleep mode if no changes occur for a specified period, preventing simulation from occurring.
https://rapier.rs/docs/user_guides/rust/rigid_bodies/#sleeping

Additionally, I've updated the example to verify that events functionality at all times.
<img width="1234" height="745" alt="image" src="https://github.com/user-attachments/assets/00fa146e-8605-4415-b7de-d122e95bc9ce" />
